### PR TITLE
Loosen xcodeproj dependency

### DIFF
--- a/mayday.gemspec
+++ b/mayday.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'clamp', '~> 0.6.3'
   spec.add_dependency 'colorize', '~> 0.7.3'
   spec.add_dependency 'sourcify', '~> 0.6.0rc4'
-  spec.add_dependency 'xcodeproj', '~> 0.19.3'
+  spec.add_dependency 'xcodeproj', '~> 0.20'
 end


### PR DESCRIPTION
Seems to work for 0.20 and 0.22 -- no major notes that I could find on
the project either. This seems safe enough.

This will let cocoapods 0.35.0+ users have mayday in their Gemfile

Test output:


```sh
** BUILD FAILED **


The following build commands failed:
	PhaseScriptExecution Generate\ Mayday\ Flags /Users/dlyon/Library/Developer/Xcode/DerivedData/Fixtures-bpnxkuhmszklrcgghtzpvipgbhuh/Build/Intermediates/Fixtures.build/Debug-iphonesimulator/Fixtures.build/Script-088390F2436DA1FB76AB34F7.sh
(1 failure)
....2015-02-28 12:21:48.288 xcodebuild[28279:30182947] [MT] iPhoneSimulator: Unable to connect to "com.apple.instruments.deviceservice.lockdown" (Error Domain=com.apple.CoreSimulator.SimError Code=146 "Unable to lookup in current state: Shutdown" UserInfo=0x7f946fc029e0 {NSLocalizedDescription=Unable to lookup in current state: Shutdown})

Testing failed:
	Please remove Copyright boilerplate
** TEST FAILED **


The following build commands failed:
	PhaseScriptExecution Generate\ Mayday\ Flags /Users/dlyon/Library/Developer/Xcode/DerivedData/Fixtures-bpnxkuhmszklrcgghtzpvipgbhuh/Build/Intermediates/Fixtures.build/Debug-iphonesimulator/Fixtures.build/Script-088390F2436DA1FB76AB34F7.sh
(1 failure)
......Maydayfile_doesnt_exist created
./Users/dlyon/proj/mayday/spec/test_fixtures/Maydayfile already exists
..              user     system      total        real
Mayday    0.020000   0.000000   0.020000 (  0.014101)
..No Xcode project specified in Maydayfile_rspec_generated. Specify one using xcode_proj 'Path/To/MyProject.xcodeproj'
.No Xcode project specified in Maydayfile_rspec_generated. Specify one using xcode_proj 'Path/To/MyProject.xcodeproj'
.

Finished in 5.59 seconds
17 examples, 0 failures